### PR TITLE
Separate `cluster_name` and `name` variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ module "kops_vault_backend" {
   source       = "git::https://github.com/cloudposse/terraform-aws-kops-vault-backend.git?ref=master"
   namespace    = "cp"
   stage        = "prod"
-  name         = "domain.com"
+  name         = "vault-backend"
+  cluster_name = "us-east-1.cloudposse.com"
   nodes_name   = "nodes"
 
   tags = {
-    Cluster = "k8s.domain.com"
+    Cluster = "us-east-1.cloudposse.com"
   }
 }
 ```
@@ -24,15 +25,16 @@ module "kops_vault_backend" {
 
 ## Variables
 
-|  Name              |  Default     |  Description                                                                     | Required |
-|:-------------------|:-------------|:---------------------------------------------------------------------------------|:--------:|
-| `namespace`        | ``           | Namespace (_e.g._ `cp` or `cloudposse`)                                          | Yes      |
-| `stage`            | ``           | Stage (_e.g._ `prod`, `dev`, `staging`)                                          | Yes      |
-| `name`             | ``           | Name of the Kops DNS zone (_e.g._ `domain.com`)                                  | Yes      |
-| `attributes`       | `[]`         | Additional attributes (_e.g._ `1`)                                               | No       |
-| `tags`             | `{}`         | Additional tags  (_e.g._ `map("BusinessUnit","XYZ")`                             | No       |
-| `delimiter`        | `-`          | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`      | No       |
-| `nodes_name`       | `nodes`      | Kops nodes subdomain name in the Kops DNS zone                                   | No       |
+|  Name              |  Default        |  Description                                                                     | Required |
+|:-------------------|:----------------|:---------------------------------------------------------------------------------|:--------:|
+| `namespace`        | ``              | Namespace (_e.g._ `cp` or `cloudposse`)                                          | Yes      |
+| `stage`            | ``              | Stage (_e.g._ `prod`, `dev`, `staging`)                                          | Yes      |
+| `cluster_name`     | ``              | Cluster name (_e.g._ `us-east-1.cloudposse.com`)                                 | Yes      |
+| `name`             | `vault-backend` | Name (_e.g._ `vault-backend`)                                                    | No       |
+| `attributes`       | `[]`            | Additional attributes (_e.g._ `1`)                                               | No       |
+| `tags`             | `{}`            | Additional tags  (_e.g._ `map("Cluster","us-east-1.cloudposse.com")`             | No       |
+| `delimiter`        | `-`             | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`       | No       |
+| `nodes_name`       | `nodes`         | Kops nodes subdomain name in the cluster DNS zone                                | No       |
 
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "label" {
 
 module "kops_metadata" {
   source     = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.1.1"
-  dns_zone   = "${var.name}"
+  dns_zone   = "${var.cluster_name}"
   nodes_name = "${var.nodes_name}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -10,13 +10,14 @@ variable "stage" {
 
 variable "name" {
   type        = "string"
-  description = "Name of the Kops DNS zone (e.g. `domain.com`)"
+  default     = "vault-backend"
+  description = "Name (e.g. `vault-backend`)"
 }
 
 variable "delimiter" {
   type        = "string"
   default     = "-"
-  description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
+  description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
@@ -31,8 +32,13 @@ variable "tags" {
   description = "Additional tags (e.g. map(`BusinessUnit`,`XYZ`)"
 }
 
+variable "cluster_name" {
+  type        = "string"
+  description = "Kops cluster name (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`)"
+}
+
 variable "nodes_name" {
   type        = "string"
   default     = "nodes"
-  description = "Kops nodes subdomain name in the Kops DNS zone"
+  description = "Kops nodes subdomain name in the cluster DNS zone"
 }


### PR DESCRIPTION
## what
* Separate `cluster_name` and `name` variables

## why
* Use `name` variable for all created resources (S3 buckets, IAM Roles, etc.)
* Use `cluster_name` as a pattern to lookup Kops clusters
